### PR TITLE
Prevent align none images from being indented

### DIFF
--- a/assets/styles/prince/style.scss
+++ b/assets/styles/prince/style.scss
@@ -10,3 +10,7 @@ $type: 'prince';
 @import '../components/section-titles';
 @import '../components/structure';
 @import '../components/toc';
+
+p+p:has(img.alignnone) {
+    text-indent: 0;
+}


### PR DESCRIPTION
Pressbooks wraps images in paragraph tags if they aren’t already in one, so what this does is it sets the `text-indent` to 0 for any paragraphs which contain an image with the `.alignnone` class.